### PR TITLE
docs: fix cross-reference link to scoping doc

### DIFF
--- a/content/en/docs/topics/config/index.md
+++ b/content/en/docs/topics/config/index.md
@@ -102,7 +102,7 @@ WordTemplate = \b(?:%s)\b
 ### Format associations
 
 Format associations allow you to associate an "unknown" file extension with
-a supported [file format](scoping):
+a supported [file format]({{< ref "scoping" >}}):
 
 ```ini
 [formats]


### PR DESCRIPTION
This change updates a cross-reference link that previously pointed to a wrong location and thrown 404