### PR TITLE
:feat: Document the spelling style key `append`

### DIFF
--- a/content/en/docs/topics/styles/index.md
+++ b/content/en/docs/topics/styles/index.md
@@ -426,6 +426,7 @@ into its `message` format specifier (`%s`).
 | `ignore`       | `string` | A relative path \(from `StylesPath`\) to a file consisting of one word per line to ignore.  |
 | `dicpath`      | `string` | The location to look for `.dic` and `.aff` files.                                           |
 | `dictionaries` | `array`  | An array of dictionaries to load.                                                           |
+| `append`       | `bool`   | Adds the array of dictionaries after the default Vale dictionary, instead of replacing it.  |
 {{< /details >}}
 
 ```yaml


### PR DESCRIPTION
The `Key summary` table for `spelling` does not list the `append` keyword, which is necessary if one wants to use the Vale default dictionary as well as additional dictionaries.