### PR TITLE
Improve docs for using BlockIgnores and TokenIgnores

### DIFF
--- a/content/en/docs/topics/config/index.md
+++ b/content/en/docs/topics/config/index.md
@@ -152,23 +152,41 @@ Style1.Rule2 = error
 
 #### BlockIgnores
 
+`BlockIgnores` allow you to exclude certain block-level sections of text that
+don't have an associated HTML tag that could be used with [`SkippedScopes`](#skippedscopes).
+
 ```ini
 [*]
 BlockIgnores = (?s) *({< file [^>]* >}.*?{</ ?file >})
 ```
 
-`BlockIgnores` allow you to exclude certain block-level sections of text that
-don't have an associated HTML tag that could be used with `SkippedScopes`.
+The basic idea is to capture the entire block in the first grouping. See
+[regex101](https://regex101.com/r/mFM0kZ/1/) for a more thorough explanation.
+
+You can also define more than one block by using a list \(the `\` allows for line
+breaks\):
+
+```ini
+BlockIgnores = (?s) *({< output >}.*?{< ?/ ?output >}), \
+(?s) *({< highlight .* >}.*?{< ?/ ?highlight >})
+```
+
+See [Non-standard markup](/docs/topics/scoping/#non-standard-markup) for more usage examples.
 
 #### TokenIgnores
+
+`TokenIgnores` allow you to exclude certain inline-level sections of text that
+don't have an associated HTML tag that could be used with [`IgnoredScopes`](#ignoredscopes).
 
 ```ini
 [*]
 TokenIgnores = (\$+[^\n$]+\$+)
 ```
 
-`TokenIgnores` allow you to exclude certain inline-level sections of text that
-don't have an associated HTML tag that could be used with `IgnoredScopes`.
+The basic idea is to capture the entire inline-level section in the first grouping. See
+[regex101](https://regex101.com/r/mFM0kZ/1/) for a more thorough explanation.
+
+See [Non-standard markup](/docs/topics/scoping/#non-standard-markup) for more usage examples.
 
 #### Transform
 

--- a/content/en/docs/topics/scoping/index.md
+++ b/content/en/docs/topics/scoping/index.md
@@ -175,7 +175,9 @@ BasedOnStyles = Vale
 ## Non-standard markup
 
 When working with non-HTML markup, you'll probably find that there are certain
-non-standard sections of text you'd like to ignore. This is possible using [`BlockIgnores`](/docs/topics/config/#blockignores) and [`TokenIgnores`](/docs/topics/config/#tokenignores). Some examples:
+non-standard sections of text you'd like to ignore. This is possible using
+[`BlockIgnores`](/docs/topics/config/#blockignores) and
+[`TokenIgnores`](/docs/topics/config/#tokenignores). Some examples:
 
 {{< tabs formats >}}
 

--- a/content/en/docs/topics/scoping/index.md
+++ b/content/en/docs/topics/scoping/index.md
@@ -97,6 +97,8 @@ reStructuredText is supported through the external program
 
 Vale ignores literal blocks, inline literals, and `code-block`s by default. The supported extensions are `.rst` and `.rest`.
 
+See [Non-standard markup](#non-standard-markup) for more information on ignoring other types of markup.
+
 ### AsciiDoc
 
 AsciiDoc is supported through the external program [Asciidoctor](https://rubygems.org/gems/asciidoctor).
@@ -173,51 +175,7 @@ BasedOnStyles = Vale
 ## Non-standard markup
 
 When working with non-HTML markup, you'll probably find that there are certain
-non-standard sections of text you'd like to ignore.
+non-standard sections of text you'd like to ignore. This is possible using [`BlockIgnores`](/docs/topics/config/#blockignores) and [`TokenIgnores`](/docs/topics/config/#tokenignores). Some examples:
 
-To ignore entire blocks of text—for example,
-[Hugo's shortcodes](https://gohugo.io/content-management/shortcodes/)—you'll
-want to define `BlockIgnores`. For example, consider the following
-shortcode-like `file` snippet:
-
-```text
-{< file "hello.go" go >}
-package main
-
-func main() {
-    fmt.Printf("hello, world\n")
-}
-{</ file >}
-```
-
-To ignore all instances of `file`, we'd use a pattern along the lines of the
-following:
-
-```ini
-BlockIgnores = (?s) *({< file [^>]* >}.*?{</ ?file >})
-```
-
-The basic idea is to capture the entire snippet in the first grouping. See
-[regex101](https://regex101.com/r/mFM0kZ/1/) for a more thorough explanation.
-
-You can also define more than one by using a list \(the `\` allows for line
-breaks\):
-
-```ini
-BlockIgnores = (?s) *({< output >}.*?{< ?/ ?output >}), \
-(?s) *({< highlight .* >}.*?{< ?/ ?highlight >})
-```
-
-To ignore an inline section of text, you'll want to define `TokenIgnores`. For
-example, let's say we want to ignore math equations of the form `$...$`:
-
-```latex
-$\begin{bmatrix} k & k & k \end{bmatrix}^T$
-```
-
-Similar to `BlockIgnores`, we just need to define a pattern:
-
-```ini
-TokenIgnores = (\$+[^\n$]+\$+)
-```
+{{< tabs formats >}}
 

--- a/content/en/docs/topics/scoping/tabs/formats.yml
+++ b/content/en/docs/topics/scoping/tabs/formats.yml
@@ -1,0 +1,54 @@
+- title: Hugo Shortcodes
+  active: true
+  body: |
+    To ignore entire blocks of text, you'll
+    want to define `BlockIgnores`. Consider the following
+    [shortcode-like](https://gohugo.io/content-management/shortcodes/) `file` snippet:
+
+    ```text
+    {< file "hello.go" go >}
+    package main
+
+    func main() {
+        fmt.Printf("hello, world\n")
+    }
+    {</ file >}
+    ```
+
+    To ignore all instances of `file`, we'd use a pattern along the lines of the
+    following:
+
+    ```ini
+    BlockIgnores = (?s) *({< file [^>]* >}.*?{</ ?file >})
+    ```
+
+- title: Markdown
+  body: |
+    To ignore an inline section of text you'll want to define `TokenIgnores`.
+    Let's say we want to ignore math equations of the form `$...$`, that look something like:
+
+    ```latex
+    $\begin{bmatrix} k & k & k \end{bmatrix}^T$
+    ```
+
+    To ignore all instances of math equations, we'd use a pattern along the lines of the
+    following:
+
+    ```ini
+    TokenIgnores = (\$+[^\n$]+\$+)
+    ```
+
+- title: reStructuredText
+  body: |
+    To ignore directive blocks use `BlockIgnores`. For example, ignoring `.. math::` directives:
+
+    ```ini
+    BlockIgnores = (?s) *(\.\. math::)
+    ```
+
+    To ignore inline roles use `TokenIgnores`. For example, ignoring `:math:` roles:
+
+    ```ini
+    TokenIgnores = (:math:`.*`)
+    ```
+

--- a/content/en/docs/topics/scoping/tabs/formats.yml
+++ b/content/en/docs/topics/scoping/tabs/formats.yml
@@ -1,9 +1,9 @@
 - title: Hugo Shortcodes
   active: true
   body: |
-    To ignore entire blocks of text, you'll
-    want to define `BlockIgnores`. Consider the following
-    [shortcode-like](https://gohugo.io/content-management/shortcodes/) `file` snippet:
+    To ignore entire blocks of text, you'll want to define `BlockIgnores`.
+    Consider the following [shortcode-like](https://gohugo.io/content-management/shortcodes/)
+    `file` snippet:
 
     ```text
     {< file "hello.go" go >}


### PR DESCRIPTION
This PR comes from the discussion in https://github.com/errata-ai/vale/discussions/562. I had a difficult time understanding how to ignore reStructuredText directives/roles from reading the docs, and was hoping to make it easier for the next user.

## Summary of Changes

- Add markup tabs to [Non-standard markup](https://deploy-preview-25--eclectic-semifreddo-be083c.netlify.app/docs/topics/scoping#non-standard-markup) section, so that examples can be given for more than one markup.
- Move applicable content to the [BlockIgnores](https://deploy-preview-25--eclectic-semifreddo-be083c.netlify.app/docs/topics/config/#blockignores) and [TokenIgnores](https://deploy-preview-25--eclectic-semifreddo-be083c.netlify.app/docs/topics/config/#tokenignores) sections where it seemed to be a better source of truth.

Signed-off-by: Jared Dillard <jared.dillard@gmail.com>