### PR TITLE
Fix build previews for the docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ build:
 
 preview:
 	$(call build_index)
-	npm run build -- -b $DEPLOY_PRIME_URL
+	npm run build -- -b ${DEPLOY_PRIME_URL}


### PR DESCRIPTION
Previously, assets were 404ing due to malformed URLs that contained `EPLOY_PRIME_URL`. Example from [broken preview](https://deploy-preview-25--eclectic-semifreddo-be083c.netlify.app/docs/topics/scoping/):
```
https://deploy-preview-25--eclectic-semifreddo-be083c.netlify.app/docs/topics/scoping/EPLOY_PRIME_URL/fonts/vendor/jost/jost-v4-latin-regular.woff2
```