### PR TITLE
Add Rust and PowerShell to code comments list

### DIFF
--- a/content/en/docs/topics/scoping/code.yml
+++ b/content/en/docs/topics/scoping/code.yml
@@ -71,6 +71,12 @@ data:
       `#` (`text.comment.line.ext`),
       `/*...*/` (`text.comment.line.ext`),
       `/*` (`text.comment.block.ext`)
+  - language: PowerShell
+    extensions: "`.ps1`"
+    scopes: |
+      `#` (`text.comment.line.ext`),
+      `<#...#>` (`text.comment.line.ext`),
+      `<#` (`text.comment.block.ext`)
   - language: Python
     extensions: "`.py`, `.py3`, `.pyw`, `.pyi`, `rpy`"
     scopes: |

--- a/content/en/docs/topics/scoping/code.yml
+++ b/content/en/docs/topics/scoping/code.yml
@@ -85,6 +85,10 @@ data:
     scopes: |
       `#` (`text.comment.line.ext`),
       `^=begin` (`text.comment.block.ext`)
+  - language: Rust
+    extensions: "`.rs`"
+    scopes: |
+      `//` (`text.comment.line.ext`)
   - language: Sass
     extensions: "`.sass`"
     scopes: |


### PR DESCRIPTION
## Summary of changes

Rust and [PowerShell](https://github.com/errata-ai/vale/releases/tag/v2.23.1) were missing from the [Code](https://vale.sh/docs/topics/scoping/#code-1) list. Taken from [`format.go`](https://github.com/sdwheeler/vale/blob/v2/internal/core/format.go).

**Code comment syntax documentation**:
- [Rust](https://doc.rust-lang.org/book/ch03-04-comments.html)
- [PowerShell](https://ss64.com/ps/syntax-comments.html)

Closes https://github.com/errata-ai/vale.sh/issues/31

## Preview

- [Code](https://deploy-preview-32--eclectic-semifreddo-be083c.netlify.app/docs/topics/scoping/#code-1)