### PR TITLE
Update vocab/index.md and styles/index.md

### DIFF
--- a/content/en/docs/topics/styles/index.md
+++ b/content/en/docs/topics/styles/index.md
@@ -15,7 +15,7 @@ toc: true
 
 Vale has a powerful extension system to enforce particular writing
 constructs. Vale uses collections of individual
-[YAML](http://yaml.org) files (or "rules") amd doesn't require knowledge of
+[YAML](http://yaml.org) files (or "rules") and doesn't require knowledge of
 any programming language.
 
 ```yaml

--- a/content/en/docs/topics/styles/index.md
+++ b/content/en/docs/topics/styles/index.md
@@ -13,10 +13,10 @@ toc: true
 
 ## Overview
 
-Vale has a powerful extension system that doesn't require knowledge of
-any programming language. Instead, it uses collections of individual
-[YAML](http://yaml.org) files (or "rules") to enforce particular writing
-constructs.
+Vale has a powerful extension system to enforce particular writing
+constructs. Vale uses collections of individual
+[YAML](http://yaml.org) files (or "rules") amd doesn't require knowledge of
+any programming language.
 
 ```yaml
 # An example rule from the "Microsoft" style.
@@ -460,20 +460,17 @@ environment variable or the `dicpath` key.
 
 `spelling` offers two different ways of ignoring non-dictionary words:
 
-1. Using *ignore* files: Ignore files are plain-text files
-   that list words to be ignored during spell check (one case-insensitive entry
-   per line) . For example,
+- Using plain-text *ignore* files that list words to be ignored during spell check. You can name these files anything you'd like and add one case-insensitive entry
+   per line, for example:
 
    ```text title="ignore.txt"
    destructuring
    transpiler
    ```
 
-   Here, we're instructing `spelling` to ignore both
-   `[Dd]estructuring` and `[Tt]ranspiler`.
+   Here, `spelling` will ignore both `[Dd]estructuring` and `[Tt]ranspiler`.
 
-   You can name these files anything you'd like and reference them relative to
-   the active `StylesPath`:
+   In your spelling rule(s), you must reference the *ignore* file(s) relative to the active `StylesPath`:
 
    ```yaml
    extends: spelling
@@ -485,9 +482,7 @@ environment variable or the `dicpath` key.
      - ignore2.txt
    ```
 
-2. Using *filters*: You can also customize the spell-checking experience by
-   defining *filters*, which are Go-compatible
-   regular expressions to applied to individual words:
+- Using *filters* that define Go-compatible regular expressions to be applied to individual words:
 
    ```yaml
    extends: spelling

--- a/content/en/docs/topics/vocab/index.md
+++ b/content/en/docs/topics/vocab/index.md
@@ -104,13 +104,11 @@ understanding how Vale handles case sensitivity.
 
 Vale's `Vocab` files are case-aware by default while most spell-checking tools ignore case.
 
-For example, a vocabulary consisting of
+For example, the following vocabulary file will enforce the *exact* use of "MongoDB": "mongoDB," "MongoDb," etc.
 
 ```text
 MongoDB
 ```
-
-will enforce the *exact* use of "MongoDB": "mongoDB," "MongoDb," etc.
 
 To provide case-insensitive checks, you have two options:
 

--- a/content/en/docs/topics/vocab/index.md
+++ b/content/en/docs/topics/vocab/index.md
@@ -102,49 +102,43 @@ mentioned above) and may also be regular expressions.
 An important factor in successfully implementing a custom `Vocab` is
 understanding how Vale handles case sensitivity.
 
-While most spell-checking tools ignore case altogether, Vale's `Vocab` files
-are case-aware by default. This means that, for example, a vocabulary
-consisting of
+Vale's `Vocab` files are case-aware by default while most spell-checking tools ignore case.
+
+For example, a vocabulary consisting of
 
 ```text
 MongoDB
 ```
 
-will enforce the *exact* use of "MongoDB": "mongoDB," "MongoDb," etc., will all
-result in errors. There are two ways around this.
+will enforce the *exact* use of "MongoDB": "mongoDB," "MongoDb," etc.
 
-First, you can indicate that a given entry should be case-insensitive by
-providing an appropriate regular expression:
+To provide case-insensitive checks, you have two options:
 
-```text
-(?i)MongoDB
-[Oo]bservability
-```
+- You can provide a regular expression:
 
-The entry, `(?i)MongoDB`, marks the entire pattern as case-insensitive while
-the second, `[Oo]bservability`, provides two acceptable options.
+    ```text
+    (?i)MongoDB
+    [Oo]bservability
+    ```
 
-Second, you can disable `Vale.Terms` and just use `Vale.Spelling`:
+    `(?i)MongoDB` marks the entire pattern as case-insensitive.  
+    `[Oo]bservability` provides two acceptable options.
 
-```ini
-BasedOnStyles = Vale
+- You can disable `Vale.Terms` and just use `Vale.Spelling`:
 
-Vale.Terms = NO
-```
+    ```ini
+    BasedOnStyles = Vale
 
-This will provide a more traditional spell-checking experience.
+    Vale.Terms = NO
+    ```
 
-## Relation to ignore files
+## Difference between vocabularies and ignore files
 
-The functionality of vocabularies is similar to the existing concept of
-[*ignore* files](/docs/topics/styles/#ignoring-non-dictionary-words).
+In comparison to [*ignore* files](/docs/topics/styles/#ignoring-non-dictionary-words), 
+vocabularies apply to multiple extension points (rather than just `spelling`), 
+support regular expressions, and have built-in rules (`Vale.Terms` and `Vale.Avoid`).
 
-The major differences are that vocabularies apply to multiple extension points
-(rather than just `spelling`), support regular expressions, and have built-in
-rules associated with them (`Vale.Terms` and `Vale.Avoid`).
-
-In general, this means that ignore files are for style *creators* while
-vocabularies are for style *users*:
+Ignore files are for style *creators* while vocabularies are for style *users*:
 
 * If you're developing or maintaining a style, you may still want to include a
   custom `spelling` rule&mdash;`MyStyle.Spelling`&mdash;that packages its own
@@ -154,7 +148,7 @@ vocabularies are for style *users*:
   files completely.
 
 For example, if you were using `Vale.Spelling` with a `<StylesPath>/vocab.txt`
-file prior to `v2.3`, you can simply copy the contents of `vocab.txt` into
+file prior to `v2.3`, you can copy the contents of `vocab.txt` into
 `<StylesPath>/Vocab/<MyVocab>/accept.txt` and it'll work the same (you may
 also want to disable `Vale.Terms` and `Vale.Avoid` to replicate the exact
 experience).

--- a/content/en/docs/topics/vocab/index.md
+++ b/content/en/docs/topics/vocab/index.md
@@ -37,22 +37,22 @@ consisting of two plain-text files&mdash;`accept.txt` and
 `reject.txt`&mdash;that contain one word, phrase, or regular expression per
 line.
 
-The effects of using a custom `Vocab` are as follows:
-
-* Entries in `accept.txt` are added to every exception list in all styles
-  listed in `BasedOnStyles`&mdash;meaning that you now only need to update your
-  project's *vocabulary* to customize third-party styles (rather than the
+Entries in `accept.txt` will be added to every exception list in all styles
+  listed in `BasedOnStyles`. To customize third-party styles, you now only 
+  need to update your project's *vocabulary* (rather than the
   styles themselves).
+  
+A custom `Vocab` automatically affects your rules as follows:
 
-* Entries in `accept.txt` are automatically added to a substitution rule
+* `accept.txt` entries are added to a substitution rule
   (`Vale.Terms`), ensuring that any occurrences of these words or phrases
   exactly match their corresponding entry in `accept.txt`.
 
-* Entries in `reject.txt` are automatically added to an existence rule
+* `reject.txt` entries are added to an existence rule
   (`Vale.Avoid`) that will flag all occurrences as errors.
 
-This means that your exceptions can be developed independent of a style,
-allowing you to use the same exceptions with multiple styles or switch styles
+This allows you to develop exceptions independent of a style. 
+You can use the same exceptions with multiple styles or switch styles
 without having to re-implement them.
 
 ## Folder structure

--- a/content/en/docs/topics/vocab/index.md
+++ b/content/en/docs/topics/vocab/index.md
@@ -104,7 +104,7 @@ understanding how Vale handles case sensitivity.
 
 Vale's `Vocab` files are case-aware by default while most spell-checking tools ignore case.
 
-For example, the following vocabulary file will enforce the *exact* use of "MongoDB": "mongoDB," "MongoDb," etc.
+For example, the following vocabulary file will enforce the *exact* use of "MongoDB". Other notations will result in errors.
 
 ```text
 MongoDB


### PR DESCRIPTION
I started using Vale to implement it in our docs build process. I managed to get vocab and spelling rules to work in parallel. I had a hard time understanding vocab ignore files (if supported at all with Vale.Spelling).

I think the docs are quite complex in some parts, especially for beginners, for example [this part about multiple extension points](https://github.com/errata-ai/vale.sh/pull/35/files#diff-d5b31953534737ff0008e9bcfa6277c002618d53608aa477293cdb1512d40249R135), The "built-in rules (`Vale.Terms` and `Vale.Avoid`)" are unclear to me. 

A rule in one of the Vale packages told me to remove "[simply](https://github.com/errata-ai/vale.sh/pull/35/files#diff-d5b31953534737ff0008e9bcfa6277c002618d53608aa477293cdb1512d40249L157)" ;)