### PR TITLE
docs(vocab): Clarify multiple vocabulary usage

### DIFF
--- a/content/en/docs/topics/vocab/index.md
+++ b/content/en/docs/topics/vocab/index.md
@@ -32,10 +32,11 @@ Vocab = Some-Name
 BasedOnStyles = Vale, MyStyle
 ```
 
-Each `Vocab` is a single folder (stored at `<StylesPath>/Vocab/<name>/`)
-consisting of two plain-text files&mdash;`accept.txt` and
-`reject.txt`&mdash;that contain one word, phrase, or regular expression per
-line.
+Each `Vocab` is a single folder (stored at `<StylesPath>/Vocab/<name>/`) consisting of
+two plain-text files&mdash;`accept.txt` and `reject.txt`&mdash;that contain one word,
+phrase, or regular expression per line. Vocabularies cannot be defined in
+format-specific settings.  Use multiple config files to use different vocabularies for
+different formats.
 
 The effects of using a custom `Vocab` are as follows:
 


### PR DESCRIPTION
A big point of confusion for me getting started with Vale was how to use different vocabularies for code comments than for markup and text.  I ended up doing some trial and error to figure out the behavior of the `Vocab` setting.  Hopefully this, or some other clarifying language might save others the same confusion.