### PR TITLE
docs: fix .gitignore code snippet

### DIFF
--- a/content/en/docs/topics/packages/index.md
+++ b/content/en/docs/topics/packages/index.md
@@ -135,11 +135,17 @@ that you'll also have some local components  as well.
 # `Vocab/Base` folder.
 
 .github/styles/*
+!.github/styles/Vocab/
+
+.github/styles/Vocab/*
 !.github/styles/Vocab/Base
 ```
 
 The above example ignores the entire `.github/styles/` folder *except* for
-`.github/styles/Vocab/Base` (which we want to track changes for).
+`.github/styles/Vocab/Base` (which we want to track changes for). 
+The rules to ignore subfolders are written in pairs, because Git disregards
+skip-level unignore rules. Any unignored item should have its parent folder
+unignored as well.
 
 [1]: /hub/write-good/
 [2]: /hub/hugo/


### PR DESCRIPTION
I couldn't unignore a subfolder in `Vocab` using the code snippet from the documentation:

```
.github/styles/*
!.github/styles/Vocab/Base
```

Found a solution [here](https://stackoverflow.com/a/5534865/10308406).