### PR TITLE
Docs: Add CircleCI orb to integrations menu

### DIFF
--- a/config/_default/menus.toml
+++ b/config/_default/menus.toml
@@ -37,6 +37,13 @@ url = "https://github.com/errata-ai/vale-action"
 weight = 120
 
 [[docs]]
+identifier = "circleci"
+name = "CircleCI"
+parent = "integrations"
+url = "https://circleci.com/developer/orbs/orb/circleci/vale"
+weight = 120
+
+[[docs]]
 identifier = "laravel"
 name = "Laravel"
 parent = "integrations"


### PR DESCRIPTION
Hello Errata Ai! 

My name is Kyle Tryon, I work for CircleCI mostly creating "Orbs" for our platform. These are CircleCI's version of CI plugins, like Jenkin's plugins or Github's Actions.

Our documentation team recently discovered your tool and is looking to adopt it for use with the CircleCI documentation. To assist them and other member of the community, we have created a CircleCI orb for Vale. If you are at all interested in owning this integration we are very much open to transferring it 👍 . 

You can find the orb here: https://circleci.com/developer/orbs/orb/circleci/vale

Usage looks like:

```yaml
version: '2.1'
orbs:
  vale: circleci/vale@1.0.0
workflows:
  lint:
    jobs:
      - vale/lint

```

The change in this PR adds the external link to the integrations menu along side GitHub actions and the other IDE plugins

<img width="317" alt="image" src="https://github.com/errata-ai/vale.sh/assets/33272306/eba3a7a8-b18b-417d-94be-ddd7786859b4">
