### PR TITLE
Document implicit script interface

### DIFF
--- a/content/en/docs/topics/styles/index.md
+++ b/content/en/docs/topics/styles/index.md
@@ -610,10 +610,10 @@ script: |
   }
 ```
 
-Scripts must define a `matches` variable with an array value.
+In order to return rule matches, scripts must define a `matches` variable with an array value.
 To initialize an empty `matches` variable, use `matches := []`.
 
-A match must be a map with the keys `begin` and `end` set to integer indexes.
+A match must be a map with the keys `begin` and `end` set to integer indexes into the `scope`.
 For more information about map values, refer to [Tengo Language Syntax | Map values](https://github.com/d5/tengo/blob/master/docs/tutorial.md#map-values).
 
 All scripts have access to Tengo's [`text`](https://github.com/d5/tengo/blob/master/docs/stdlib-text.md) module, which provides a number of

--- a/content/en/docs/topics/styles/index.md
+++ b/content/en/docs/topics/styles/index.md
@@ -610,6 +610,12 @@ script: |
   }
 ```
 
+Scripts must define a `matches` variable with an array value.
+To initialize an empty `matches` variable, use `matches := []`.
+
+A match must be a map with the keys `begin` and `end` set to integer indexes.
+For more information about map values, refer to [Tengo Language Syntax | Map values](https://github.com/d5/tengo/blob/master/docs/tutorial.md#map-values).
+
 All scripts have access to Tengo's [`text`](https://github.com/d5/tengo/blob/master/docs/stdlib-text.md) module, which provides a number of
 string- and regex-related utility functions.
 


### PR DESCRIPTION
Although the example demonstrates it, I think explicitly stating that the script needs to define a `matches` variable will help new readers.