### PR TITLE
Docs: Add a note regarding `.yml` extension for custom style rules

### DIFF
--- a/content/en/docs/topics/styles/index.md
+++ b/content/en/docs/topics/styles/index.md
@@ -56,6 +56,13 @@ styles/
 where _base_, _blog_, and _docs_ are your styles that each contain certain
 rules.
 
+{{< alert context="info">}}
+**Heads up**!
+
+Make sure your rule files end in extension `.yml`. Do not end them in `.yaml`,
+as Vale will not detect them.
+{{< /alert >}}
+
 ## Extension points
 
 {{< alert context="info">}}


### PR DESCRIPTION
For a recent project of mine that uses Vale, I recently spent a very very long time debugging why one of my rules seemed to not get picked up by Vale. I eventually realized that `.yaml` extension appeared to be the cause—renaming to `.yml` caused the rule to get picked up.

This PR adds a heads-up to the relevant section in docs. Hopefully others won't have to make the same mistake as me. 😅 