### PR TITLE
Add Datadog To List of Companies Using Vale on Home Page

### DIFF
--- a/data/configs.yml
+++ b/data/configs.yml
@@ -131,3 +131,10 @@
   org: https://github.com/grafana
   website: https://grafana.com/
   name: Grafana Labs
+
+- source: https://github.com/datadog/documentation/blob/master/.vale.ini
+  docs: https://github.com/datadog/datadog-vale
+  info: Datadog is the essential monitoring and security platform for cloud applications.
+  org: https://github.com/datadog
+  website: https://www.datadoghq.com/
+  name: Datadog


### PR DESCRIPTION
Adds Datadog as an entry in the **See how Vale is being used by...** section of the [home page](https://vale.sh/).