### PR TITLE
Remove code formatting from heading

### DIFF
--- a/content/en/docs/vale-cli/structure/index.md
+++ b/content/en/docs/vale-cli/structure/index.md
@@ -124,7 +124,7 @@ by the `Vale.Spelling` rule.
 
 See [Spelling](/docs/topics/styles/#spelling) for more information.
 
-#### `templates`
+#### templates
 
 The `templates` directory is where you can add custom output templates.
 


### PR DESCRIPTION
the heading text for "templates" was formatted as code.

see https://vale.sh/docs/vale-cli/structure/#templates

This was inconsistent and confusing when reading the page