### PR TITLE
Add Packages to config docs

### DIFF
--- a/content/en/docs/topics/config/index.md
+++ b/content/en/docs/topics/config/index.md
@@ -68,6 +68,16 @@ depends on your operating system:
 
 (Run the `vale ls-dirs` command to see the exact locations on your system.)
 
+#### Packages
+
+The list of packages to install to the `StylesPath`.
+
+After running the [`sync`](/manual/sync) command, the styles will be added to
+the active `StylesPath`, and any configuration files will be added to
+`StylesPath/.config` according to the order in which they were loaded.
+
+See [Packages](/docs/topics/packages) for more information and usage examples.
+
 #### MinAlertLevel
 
 ```ini

--- a/content/en/docs/topics/packages/index.md
+++ b/content/en/docs/topics/packages/index.md
@@ -85,7 +85,7 @@ Archive:  Hugo.zip
   inflating: Hugo/.vale.ini
 ```
 
-After running the [`sync`](/manual/sync) command, the configuration file be
+After running the [`sync`](/manual/sync) command, the configuration file will be
 added to `StylesPath/.config` according to the order in which it was loaded.
 
 ## Complete


### PR DESCRIPTION
The `Packages` key is described in a dedicated [Packages](https://vale.sh/docs/topics/packages/) topic, but is thus far not mentioned in the [Configuration](https://vale.sh/docs/topics/config/) topic.

This PR adds a section for the `Packages` key and points to the topic for details.