### PR TITLE
Commenting out script rules is not possible

### DIFF
--- a/content/en/docs/topics/config/index.md
+++ b/content/en/docs/topics/config/index.md
@@ -207,6 +207,33 @@ BlockIgnores = (?s) *({< output >}.*?{< ?/ ?output >}), \
 (?s) *({< highlight .* >}.*?{< ?/ ?highlight >})
 ```
 
+#### CommentDelimiters
+
+`CommentDelimiters` allow you to override standard, HTML comment delimiters (`<!-- -->`).
+
+Custom comment delimiters are useful when using non-standard formats which do not allow HTML-style comments.
+
+```ini
+[*.md]
+CommentDelimiters = "{/*","*/}"
+```
+
+When `CommentDelimiters` are set, you can take full advantage of [markup-based configuration](/docs/topics/scoping/#markup-based-configuration) to enable or disable specific rules within a section.  
+
+For instance, when using MDX:
+
+```markup
+{/*
+<!-- vale Google.We = NO -->
+*/}
+
+We rock!
+
+{/*
+<!-- vale Google.We = YES -->
+*/}
+```
+
 #### TokenIgnores
 
 {{< alert icon="👉" context="info">}}


### PR DESCRIPTION
Hello,

I was counting identical headings using a Tengo script, but could not toggle this rule off for a portion of the document.
If confirmed, I'd find that logical since it's doing it's own parsing but thought it'd be worth noting.

Feel free to integrate here or within the specific script rule type reference.