### PR TITLE
Fix name of config dir for config only packages

### DIFF
--- a/src/lib/content/keys/packages.md
+++ b/src/lib/content/keys/packages.md
@@ -89,7 +89,7 @@ Archive:  Hugo.zip
 ```
 
 After running the `sync` command, the configuration file will be
-added to `StylesPath/.config` according to the order in which it was loaded.
+added to `StylesPath/.vale-config` according to the order in which it was loaded.
 
 ## Complete
 


### PR DESCRIPTION
Fixed a typo -- the location of config only packages was incorrect.

