### PR TITLE
Fix documentation typo (double `\` on Windows `ini` path)

### DIFF
--- a/src/lib/content/vale-ini.md
+++ b/src/lib/content/vale-ini.md
@@ -115,7 +115,7 @@ on your operating system:
 
 | OS      | Search Locations                                   |
 | :------ | :------------------------------------------------- |
-| Windows | `%LOCALAPPDATA%\vale\\.vale.ini`                  |
+| Windows | `%LOCALAPPDATA%\vale\.vale.ini`                    |
 | macOS   | `$HOME/Library/Application Support/vale/.vale.ini` |
 | Unix    | `$XDG_CONFIG_HOME/vale/.vale.ini`                  |
 

--- a/src/lib/content/vale-ini.md
+++ b/src/lib/content/vale-ini.md
@@ -115,7 +115,7 @@ on your operating system:
 
 | OS      | Search Locations                                   |
 | :------ | :------------------------------------------------- |
-| Windows | `%LOCALAPPDATA%\\vale\\.vale.ini`                  |
+| Windows | `%LOCALAPPDATA%\vale\\.vale.ini`                  |
 | macOS   | `$HOME/Library/Application Support/vale/.vale.ini` |
 | Unix    | `$XDG_CONFIG_HOME/vale/.vale.ini`                  |
 


### PR DESCRIPTION
The `.vale.ini` path on Windows specified [in the docs](https://vale.sh/docs/vale-ini#global-configuration) has a double `\`:
![image](https://github.com/user-attachments/assets/e57d39df-5b39-4693-b935-c080259fde92)
