### PR TITLE
Typo intergrates -> integrates

### DIFF
--- a/src/lib/components/landing/Integrations.svelte
+++ b/src/lib/components/landing/Integrations.svelte
@@ -9,7 +9,7 @@
 			More than just a command-line interface.
 		</p>
 		<p class="mt-6 text-lg/8 text-neutral-500">
-			Vale intergrates with many popular apps, browsers, and platforms&mdash;including VS Code,
+			Vale integrates with many popular apps, browsers, and platforms&mdash;including VS Code,
 			Google Chrome, GitHub Actions, and more.
 		</p>
 	</div>


### PR DESCRIPTION
Fixes a typo on the `integrations.svelte` page similar [to this](https://github.com/errata-ai/vale.sh/commit/403a25546cbf8df17b47dd403e9ab81834e4c4ad)