### PR TITLE
fix double --rm flag in install.md

### DIFF
--- a/src/lib/content/install.md
+++ b/src/lib/content/install.md
@@ -46,8 +46,9 @@ Here's an example of calling Vale with locally-defined components (assuming
 `$(pwd)/fixtures/styles/demo` contains a config file):
 
 ```bash
-$ docker run --rm -v $(pwd)/styles:/styles \\
-             --rm -v $(pwd)/fixtures/styles/demo:/docs \\
+$ docker run --rm \\
+             -v $(pwd)/styles:/styles \\
+             -v $(pwd)/fixtures/styles/demo:/docs \\
              -w /docs \\
              jdkato/vale .
 ```


### PR DESCRIPTION
There seems to be a copy-paste duplication of `--rm` option in the docker example command