### PR TITLE
docs: Correct spelling of 'MongoDB' in vocab.md

### DIFF
--- a/src/lib/content/keys/vocab.md
+++ b/src/lib/content/keys/vocab.md
@@ -181,6 +181,6 @@ extends: existence
 message: Did you mean '%s'?
 vocab: false
 tokens:
-  # "MonoDB" can be in a vocab
+  # "MongoDB" can be in a vocab
   - MongoDB
 ```


### PR DESCRIPTION
The docs for https://vale.sh/docs/keys/vocab#rules-targeting-vocabulary-entries use MonoDB. Guessing MongoDB was the intent.