### PR TITLE
docs: add MegaLinter to the integrations list

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -87,6 +87,7 @@
 * [pre-commit](integrations/pre-commit.md)
 * [JetBrains](https://plugins.jetbrains.com/plugin/19613-vale-cli/docs)
 * [Laravel](https://github.com/beyondcode/laravel-prose-linter)
+* [MegaLinter](https://megalinter.io/latest/descriptors/spell_vale/)
 * [Obsidian](https://github.com/ChrisChinchilla/obsidian-vale)
 * [Oxygen XML](https://www.oxygenxml.com/doc/versions/23.1/ug-editor/topics/vale-linter-addon.html)
 * [Sublime Text](https://packagecontrol.io/packages/LSP-vale-ls)


### PR DESCRIPTION
Hi! I maintain [MegaLinter](https://megalinter.io), an open-source linters aggregator for CI — Vale ships in it out of the box as the SPELL_VALE linter ([descriptor page](https://megalinter.io/latest/descriptors/spell_vale/)).

This adds it to the Integrations list in the docs sidebar, alongside CircleCI and the GitHub Action. Thanks for Vale, it's a great tool!